### PR TITLE
Fixed some bugs in map zoom and move

### DIFF
--- a/dist/echarts-leaflet.esm.js
+++ b/dist/echarts-leaflet.esm.js
@@ -189,10 +189,13 @@ LeafletCoordSys.create = function (ecModel, api) {
       }
 
       /*
-       Encapsulate viewportRoot element into the parent element responsible for moving, avoiding direct manipulation of viewportRoot elements affecting related attributes such as offset.
+       Encapsulate viewportRoot element into
+       the parent element responsible for moving,
+       avoiding direct manipulation of viewportRoot elements
+       affecting related attributes such as offset.
       */
-      var moveContainer = document.createElement("div");
-      moveContainer.style = "position: relative;";
+      var moveContainer = document.createElement('div');
+      moveContainer.style = 'position: relative;';
       moveContainer.appendChild(viewportRoot);
 
       new CustomOverlay(moveContainer).addTo(_map);
@@ -278,7 +281,7 @@ echarts.extendComponentView({
     var moveContainer = api.getZr().painter.getViewportRoot().parentNode;
     var coordSys = leafletModel.coordinateSystem;
 
-    function moveHandler(type, target) {
+    var moveHandler = function moveHandler(type, target) {
       if (rendering) {
         return;
       }
@@ -307,7 +310,8 @@ echarts.extendComponentView({
       api.dispatchAction({
         type: 'leafletRoam'
       });
-    }
+    };
+
     /**
      * handler for map zoomEnd event
      */

--- a/dist/echarts-leaflet.js
+++ b/dist/echarts-leaflet.js
@@ -195,10 +195,13 @@
         }
 
         /*
-         Encapsulate viewportRoot element into the parent element responsible for moving, avoiding direct manipulation of viewportRoot elements affecting related attributes such as offset.
+         Encapsulate viewportRoot element into
+         the parent element responsible for moving,
+         avoiding direct manipulation of viewportRoot elements
+         affecting related attributes such as offset.
         */
-        var moveContainer = document.createElement("div");
-        moveContainer.style = "position: relative;";
+        var moveContainer = document.createElement('div');
+        moveContainer.style = 'position: relative;';
         moveContainer.appendChild(viewportRoot);
 
         new CustomOverlay(moveContainer).addTo(_map);
@@ -284,7 +287,7 @@
       var moveContainer = api.getZr().painter.getViewportRoot().parentNode;
       var coordSys = leafletModel.coordinateSystem;
 
-      function moveHandler(type, target) {
+      var moveHandler = function moveHandler(type, target) {
         if (rendering) {
           return;
         }
@@ -313,7 +316,8 @@
         api.dispatchAction({
           type: 'leafletRoam'
         });
-      }
+      };
+
       /**
        * handler for map zoomEnd event
        */

--- a/dist/echarts-leaflet.js
+++ b/dist/echarts-leaflet.js
@@ -1,8 +1,8 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('echarts/lib/echarts'), require('leaflet/src/Leaflet')) :
   typeof define === 'function' && define.amd ? define(['exports', 'echarts/lib/echarts', 'leaflet/src/Leaflet'], factory) :
-  (factory((global.leaflet = {}),global.echarts,global.L));
-}(this, (function (exports,echarts,L) { 'use strict';
+  (global = global || self, factory(global.leaflet = {}, global.echarts, global.L));
+}(this, function (exports, echarts, L) { 'use strict';
 
   var echarts__default = 'default' in echarts ? echarts['default'] : echarts;
   L = L && L.hasOwnProperty('default') ? L['default'] : L;
@@ -193,7 +193,15 @@
           var layerControlOpts = leafletModel.get('layerControl');
           L.control.layers(baseLayers, {}, layerControlOpts).addTo(_map);
         }
-        new CustomOverlay(viewportRoot).addTo(_map);
+
+        /*
+         Encapsulate viewportRoot element into the parent element responsible for moving, avoiding direct manipulation of viewportRoot elements affecting related attributes such as offset.
+        */
+        var moveContainer = document.createElement("div");
+        moveContainer.style = "position: relative;";
+        moveContainer.appendChild(viewportRoot);
+
+        new CustomOverlay(moveContainer).addTo(_map);
       }
       var map = leafletModel.__map;
 
@@ -273,13 +281,14 @@
       var rendering = true;
 
       var leaflet = leafletModel.getLeaflet();
-      var viewportRoot = api.getZr().painter.getViewportRoot();
+      var moveContainer = api.getZr().painter.getViewportRoot().parentNode;
       var coordSys = leafletModel.coordinateSystem;
-      var moveHandler = function moveHandler(type, target) {
+
+      function moveHandler(type, target) {
         if (rendering) {
           return;
         }
-        var offsetEl = viewportRoot.parentNode.parentNode;
+        var offsetEl = leaflet._mapPane;
         // calculate new mapOffset
         var transformStyle = offsetEl.style.transform;
         var dx = 0;
@@ -295,8 +304,8 @@
           dy = -parseInt(offsetEl.style.top, 10);
         }
         var mapOffset = [dx, dy];
-        viewportRoot.style.left = mapOffset[0] + 'px';
-        viewportRoot.style.top = mapOffset[1] + 'px';
+        moveContainer.style.left = mapOffset[0] + 'px';
+        moveContainer.style.top = mapOffset[1] + 'px';
 
         coordSys.setMapOffset(mapOffset);
         leafletModel.__mapOffset = mapOffset;
@@ -304,8 +313,7 @@
         api.dispatchAction({
           type: 'leafletRoam'
         });
-      };
-
+      }
       /**
        * handler for map zoomEnd event
        */
@@ -323,16 +331,22 @@
         moveHandler();
       }
 
-      leaflet.off('move', this._oldMoveHandler);
-      leaflet.off('zoom', this._oldZoomHandler);
-      leaflet.off('zoomend', this._oldZoomEndHandler);
+      if (this._oldMoveHandler) {
+        leaflet.off('move', this._oldMoveHandler);
+      }
+      if (this._oldZoomHandler) {
+        leaflet.off('zoom', this._oldZoomHandler);
+      }
+      if (this._oldZoomEndHandler) {
+        leaflet.off('zoomend', this._oldZoomEndHandler);
+      }
 
       leaflet.on('move', moveHandler);
       leaflet.on('zoom', zoomHandler);
       leaflet.on('zoomend', zoomEndHandler);
 
       this._oldMoveHandler = moveHandler;
-      this._oldZoomEndHandler = zoomHandler;
+      this._oldZoomHandler = zoomHandler;
       this._oldZoomEndHandler = zoomEndHandler;
 
       var roam = leafletModel.get('roam');
@@ -381,4 +395,4 @@
 
   Object.defineProperty(exports, '__esModule', { value: true });
 
-})));
+}));

--- a/src/LeafletCoordSys.js
+++ b/src/LeafletCoordSys.js
@@ -177,12 +177,15 @@ LeafletCoordSys.create = function(ecModel, api) {
       }
 
       /*
-       Encapsulate viewportRoot element into the parent element responsible for moving, avoiding direct manipulation of viewportRoot elements affecting related attributes such as offset.
+       Encapsulate viewportRoot element into
+       the parent element responsible for moving,
+       avoiding direct manipulation of viewportRoot elements
+       affecting related attributes such as offset.
       */
-      let moveContainer = document.createElement("div");
-      moveContainer.style = "position: relative;";
+      let moveContainer = document.createElement('div');
+      moveContainer.style = 'position: relative;';
       moveContainer.appendChild(viewportRoot);
-      
+
       new CustomOverlay(moveContainer).addTo(map);
     }
     let map = leafletModel.__map;

--- a/src/LeafletCoordSys.js
+++ b/src/LeafletCoordSys.js
@@ -175,7 +175,15 @@ LeafletCoordSys.create = function(ecModel, api) {
         const layerControlOpts = leafletModel.get('layerControl');
         L.control.layers(baseLayers, {}, layerControlOpts).addTo(map);
       }
-      new CustomOverlay(viewportRoot).addTo(map);
+
+      /*
+       Encapsulate viewportRoot element into the parent element responsible for moving, avoiding direct manipulation of viewportRoot elements affecting related attributes such as offset.
+      */
+      let moveContainer = document.createElement("div");
+      moveContainer.style = "position: relative;";
+      moveContainer.appendChild(viewportRoot);
+      
+      new CustomOverlay(moveContainer).addTo(map);
     }
     let map = leafletModel.__map;
 

--- a/src/LeafletView.js
+++ b/src/LeafletView.js
@@ -7,14 +7,14 @@ export default echarts.extendComponentView({
     let rendering = true;
 
     const leaflet = leafletModel.getLeaflet();
-    const viewportRoot = api.getZr().painter.getViewportRoot();
+    const moveContainer = api.getZr().painter.getViewportRoot().parentNode;
     const coordSys = leafletModel.coordinateSystem;
     
     function moveHandler(type, target) {
       if (rendering) {
         return;
       }
-      const offsetEl = viewportRoot.parentNode.parentNode;
+      const offsetEl = leaflet._mapPane;
       // calculate new mapOffset
       let transformStyle = offsetEl.style.transform;
       let dx = 0;
@@ -30,8 +30,8 @@ export default echarts.extendComponentView({
         dy = -parseInt(offsetEl.style.top, 10);
       }
       let mapOffset = [dx, dy];
-      viewportRoot.style.left = `${mapOffset[0]}px`;
-      viewportRoot.style.top = `${mapOffset[1]}px`;
+      moveContainer.style.left = `${mapOffset[0]}px`;
+      moveContainer.style.top = `${mapOffset[1]}px`;
 
       coordSys.setMapOffset(mapOffset);
       leafletModel.__mapOffset = mapOffset;

--- a/src/LeafletView.js
+++ b/src/LeafletView.js
@@ -9,7 +9,8 @@ export default echarts.extendComponentView({
     const leaflet = leafletModel.getLeaflet();
     const viewportRoot = api.getZr().painter.getViewportRoot();
     const coordSys = leafletModel.coordinateSystem;
-    const moveHandler = function(type, target) {
+    
+    function moveHandler(type, target) {
       if (rendering) {
         return;
       }
@@ -57,16 +58,22 @@ export default echarts.extendComponentView({
       moveHandler();
     }
 
-    leaflet.off('move', this._oldMoveHandler);
-    leaflet.off('zoom', this._oldZoomHandler);
-    leaflet.off('zoomend', this._oldZoomEndHandler);
-
+    if(this._oldMoveHandler){
+      leaflet.off('move', this._oldMoveHandler);
+    }
+    if(this._oldZoomHandler){
+      leaflet.off('zoom', this._oldZoomHandler);
+    } 
+    if(this._oldZoomEndHandler){
+      leaflet.off('zoomend', this._oldZoomEndHandler);
+    } 
+    
     leaflet.on('move', moveHandler);
     leaflet.on('zoom', zoomHandler);
     leaflet.on('zoomend', zoomEndHandler);
 
     this._oldMoveHandler = moveHandler;
-    this._oldZoomEndHandler = zoomHandler;
+    this._oldZoomHandler = zoomHandler;
     this._oldZoomEndHandler = zoomEndHandler;
 
     const roam = leafletModel.get('roam');

--- a/src/LeafletView.js
+++ b/src/LeafletView.js
@@ -9,8 +9,8 @@ export default echarts.extendComponentView({
     const leaflet = leafletModel.getLeaflet();
     const moveContainer = api.getZr().painter.getViewportRoot().parentNode;
     const coordSys = leafletModel.coordinateSystem;
-    
-    function moveHandler(type, target) {
+
+    const moveHandler = function(type, target) {
       if (rendering) {
         return;
       }
@@ -58,16 +58,16 @@ export default echarts.extendComponentView({
       moveHandler();
     }
 
-    if(this._oldMoveHandler){
+    if (this._oldMoveHandler) {
       leaflet.off('move', this._oldMoveHandler);
     }
-    if(this._oldZoomHandler){
+    if (this._oldZoomHandler) {
       leaflet.off('zoom', this._oldZoomHandler);
-    } 
-    if(this._oldZoomEndHandler){
+    }
+    if (this._oldZoomEndHandler) {
       leaflet.off('zoomend', this._oldZoomEndHandler);
-    } 
-    
+    }
+
     leaflet.on('move', moveHandler);
     leaflet.on('zoom', zoomHandler);
     leaflet.on('zoomend', zoomEndHandler);


### PR DESCRIPTION
- fixed #20
- fixed #17
    Encapsulate viewportRoot element into the parent element responsible for moving, avoiding direct affecting related attributes on viewportRoot elements such as offset.

